### PR TITLE
Initial structure of README with some content examples

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+README.md merge=union

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 Semantic shapes enable you to validate RDF graphs against a set of conditions.
 Semantic shapes can also be viewed as a description of data graphs that satisfy these conditions.
-Such descriptions may be used for a variety of purposes beside validation,
-including user interface building, code generation and data integration.
-Semantic shapes could be described in SHACL or ShEx languages.
+Such descriptions may be used for a variety of purposes besides validation,
+including user interface building, code generation, and data integration.
+Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## Contents
 
@@ -17,6 +17,7 @@ Semantic shapes could be described in SHACL or ShEx languages.
 - [Shapes Collections](#shapes-collections)
 - [Shape Conversion Tools](#shape-conversion-tools)
 - [Shape Generators](#shape-generators)
+- [Shape-based Query Generators](#shape-based-query-generators)
 - [Shape Editors, Visualizations](#shape-editors-visualizations)
 - [Declarative UIs](#declarative-uis)
 - [IDE support](#ide-support)
@@ -28,11 +29,11 @@ Semantic shapes could be described in SHACL or ShEx languages.
 
 ## SHACL Validators
 
-- [Jena SHACL](https://github.com/apache/jena/) ![GitHub last commit](https://img.shields.io/github/last-commit/apache/jena) `Apache-2.0` `Java` - Supports: SHACL Core, SHACL-SPARQL.
-- [RDF4J SHACL Sail](https://github.com/eclipse-rdf4j/rdf4j) ![GitHub last commit](https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j) `BSD-3-Clause` `Java`
+- [Apache Jena SHACL](https://github.com/apache/jena/) ![GitHub last commit](https://img.shields.io/github/last-commit/apache/jena) `Apache-2.0` `Java` - Supports: SHACL Core, SHACL-SPARQL.
+- [RDF4J SHACL Engine](https://github.com/eclipse-rdf4j/rdf4j) ![GitHub last commit](https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j) - Supports SHACL Core (without some property paths), SHACL-SPARQL, incremental validation; `BSD-3-Clause` `Java`.
+- [SHACL for Ruby](https://github.com/ruby-rdf/shacl/) ![GitHub last commit](https://img.shields.io/github/last-commit/ruby-rdf/shacl) `BSD-3-Clause` `Ruby` - A pure-Ruby library for working with the Shape Constraint Language to validate the shape of RDF graphs.
 - [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) ![GitHub last commit](https://img.shields.io/github/last-commit/TopQuadrant/shacl) `BSD-3-Clause` `Java` - Based on Jena; supports: SHACL Core, SHACL-SPARQL, SHACL rules.
 - [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) ![GitHub last commit](https://img.shields.io/github/last-commit/SHACL-X/shacl-x) `BSD-3-Clause` `Java` - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot.
-- [SHACL for Ruby](https://github.com/ruby-rdf/shacl/) ![GitHub last commit](https://img.shields.io/github/last-commit/ruby-rdf/shacl) `BSD-3-Clause` `Ruby` - A pure-Ruby library for working with the Shape Constraint Language to validate the shape of RDF graphs.
 
 ## ShEx Validators
 
@@ -59,6 +60,10 @@ Semantic shapes could be described in SHACL or ShEx languages.
 ## Shape Generators
 
 - [owl2shacl](https://github.com/sparna-git/owl2shacl) - OWL-to-SHACL conversion rules.
+
+## Shape-based Query Generators
+
+- [@hydrofoil/shape-to-query](https://github.com/hypermedia-app/shape-to-query) [docs](https://shape-to-query.hypermedia.app/docs/#extension-spo-rule) - Generate SPARQL queries from SHACL Shapes.
 
 ## Shape Editors, Visualizations
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 - [IDE support](#ide-support)
 - [Books](#books)
 - [Tutorials](#tutorials)
+- [Talks](#talks)
 - [Presentations](#presentations)
 - [Specifications](#specifications)
 - [Legend](#legend)
@@ -79,15 +80,23 @@ Data viewers/Editors based on shapes.
 
 ## IDE support
 
-- [Linked Data Extension](https://github.com/elsevierlabs-os/linked-data) - VS Code Extension for editing RDF files with embedded SHACL validator and SPARQL engine.
+- [Linked Data Extension](https://marketplace.visualstudio.com/items?itemName=Elsevier.linked-data) - VS Code Extension for editing RDF files with embedded SHACL validator and SPARQL engine.
+- [SHACL Language Server](https://marketplace.visualstudio.com/items?itemName=stardog-union.vscode-langserver-shacl) - A VS Code extension providing language intelligence (diagnostics, hover tooltips, auto-completion, etc.) for W3C standard SHACL via the Language Server Protocol.
+- [Mentor RDF for VS Code](https://marketplace.visualstudio.com/items?itemName=faubulous.mentor) - Code editing support for RDF, RDFS, OWL, SKOS, SHACL and SPARQL.
 
-## Book
+## Books
 
-- [Validating RDF Data (2018)](https://book.validatingrdf.com/)
+- [Validating RDF Data (2018)](https://book.validatingrdf.com)
 
 ## Tutorials
 
 - [Shapes applications and tools - ISWC'20 Tutorial](https://www.validatingrdf.com/tutorial/iswc2020/)
+
+## Talks
+
+- [The Many Shapes of SHACL by Holger Knublauch](https://www.youtube.com/watch?v=ccs-KhnWR1U) - LOTICO Talk, 18 Jun 2020.
+- [One Ontology, One Data Set, Multiple Shapes with SHACL by Tara Raafat](https://www.youtube.com/watch?v=apG5K3zc4V0) - Connected Data London, 2019.
+- [An Overview of SHACL Shapes Constraint Language](https://www.youtube.com/watch?v=_i3zTeMyRzU) - TopQuadrant, 2017.
 
 ## Presentations
 

--- a/README.md
+++ b/README.md
@@ -30,26 +30,26 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## SHACL Validators
 
-- [Apache Jena SHACL](https://jena.apache.org/documentation/shacl/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - Supports SHACL Core, SHACL-SPARQL; `Apache-2.0` `Java`.
-- [RDF4J SHACL Engine](https://rdf4j.org/documentation/programming/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j" align="top"> - Supports SHACL Core (without some property paths), SHACL-SPARQL, incremental validation; `BSD-3-Clause` `Java`.
-- [rdf-validate-shacl](https://github.com/zazuko/rdf-validate-shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/zazuko/rdf-validate-shacl" align="top"> - Supports SHACL Core; pure JavaScript validator on top of the [RDFJS](https://rdf.js.org/) stack; [playground](https://zazuko.github.io/shacl-playground); `MIT` `JavaScript`.
-- [SHACL for Ruby](https://github.com/ruby-rdf/shacl/) ![GitHub last commit](https://img.shields.io/github/last-commit/ruby-rdf/shacl) - A pure-Ruby library for working with the Shape Constraint Language to validate the shape of RDF graphs; `BSD-3-Clause` `Ruby`.
-- [shacl-engine](https://github.com/rdf-ext/shacl-engine) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/rdf-ext/shacl-engine" align="top"> - Supports SHACL Core, SHACL-SPARQL; A fast engine for data provided as [RDF/JS](http://rdf.js.org/data-model-spec/) objects; [playground](https://playground.rdf-ext.org/shacl/); `MIT` `JavaScript`.
-- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/TopQuadrant/shacl" align="top"> - Supports SHACL Core, SHACL-SPARQL, SHACL rules; based on Jena; `BSD-3-Clause` `Java`.
-- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/SHACL-X/shacl-x" align="top"> - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot; `BSD-3-Clause` `Java`.
+- [Apache Jena SHACL](https://github.com/apache/jena/tree/main/jena-shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - Supports SHACL Core, SHACL-SPARQL; `Apache-2.0` license; `Java`.
+- [RDF4J SHACL Engine](https://github.com/eclipse-rdf4j/rdf4j/tree/main/core/sail/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j" align="top"> - Supports SHACL Core (without some property paths), SHACL-SPARQL, incremental validation; `BSD-3-Clause` license; `Java`.
+- [rdf-validate-shacl](https://github.com/zazuko/rdf-validate-shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/zazuko/rdf-validate-shacl" align="top"> - Supports SHACL Core; pure JavaScript validator on top of the [RDFJS](https://rdf.js.org/) stack; [playground](https://zazuko.github.io/shacl-playground); `MIT` license; `JavaScript`.
+- [SHACL for Ruby](https://github.com/ruby-rdf/shacl) ![GitHub last commit](https://img.shields.io/github/last-commit/ruby-rdf/shacl) - A pure-Ruby library for working with the Shape Constraint Language to validate the shape of RDF graphs; `BSD-3-Clause` license; `Ruby`.
+- [shacl-engine](https://github.com/rdf-ext/shacl-engine) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/rdf-ext/shacl-engine" align="top"> - Supports SHACL Core, SHACL-SPARQL; A fast engine for data provided as [RDF/JS](http://rdf.js.org/data-model-spec/) objects; [playground](https://playground.rdf-ext.org/shacl/); `MIT` license; `JavaScript`.
+- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/TopQuadrant/shacl" align="top"> - Supports SHACL Core, SHACL-SPARQL, SHACL rules; based on Jena; `BSD-3-Clause` license; `Java`.
+- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/SHACL-X/shacl-x" align="top"> - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot; `BSD-3-Clause` license; `Java`.
 
 ## ShEx Validators
 
-- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - Supports ShEx, ShExC; not supported semantic actions, EXTERNAL; `Apache-2.0` `Java`.
-- [shexSpec/shex.js](https://github.com/shexjs/shex.js) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="top"> - JavaScript implementation of Shape Expressions; [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html); `MIT` `JavaScript`.
-- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator" align="top"> :skull: - A standalone Node module with a command line interface; `MIT` `JavaScript`.
-- [Validata](https://github.com/HW-SWeL/Validata) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata" align="top"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground](http://hw-swel.github.io/Validata/); [playground](https://www.w3.org/2015/03/ShExValidata/); `MIT` `JavaScript`.
+- [Apache Jena ShEx](https://github.com/apache/jena/tree/main/jena-shex) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - Supports ShEx, ShExC; not supported semantic actions, EXTERNAL; `Apache-2.0` license; `Java`.
+- [shexSpec/shex.js](https://github.com/shexjs/shex.js) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="top"> - JavaScript implementation of Shape Expressions; [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html); `MIT` license; `JavaScript`.
+- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator" align="top"> ☠️ - A standalone Node module with a command line interface; `MIT` license; `JavaScript`.
+- [Validata](https://github.com/HW-SWeL/Validata) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata" align="top"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground1](http://hw-swel.github.io/Validata/), [playground2](https://www.w3.org/2015/03/ShExValidata/); `MIT` license; `JavaScript`.
 
 ## Shapes Discovery Tools
 
-- [RDFminer](https://github.com/Wimmics/RDFminer) - Web application to automatically discover SHACL shapes representative of an RDF data graph, by Wimmics; `CECILL-C` `Java`.
-- [SHACL Discovery Service](https://github.com/AKSW/discover-shacl-shapes) - Example implementation of a discovery service for SHACL shapes/shape groups; `MIT` `PHP`.
-- [Shapes of You index](https://index.semanticscience.org/) - SPARQL queries, OWL/SKOS vocabularies, SHACL/ShEx shapes, indexed from public `git` repositories; `MIT` `Typescript, Python`.
+- [RDFminer](https://github.com/Wimmics/RDFminer) - Web application to automatically discover SHACL shapes representative of an RDF data graph, by Wimmics; `CECILL-C` license; `Java`.
+- [SHACL Discovery Service](https://github.com/AKSW/discover-shacl-shapes) - Example implementation of a discovery service for SHACL shapes/shape groups; `MIT` license; `PHP`.
+- [Shapes of You index](https://index.semanticscience.org/) - SPARQL queries, OWL/SKOS vocabularies, SHACL/ShEx shapes, indexed from public `git` repositories; `MIT` license; `Typescript`, `Python`.
 
 ## Shapes Collections
 
@@ -57,7 +57,7 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## Shape Conversion Tools
 
-- [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter" align="top"> :skull: - Shape shifter from SHACL to other formats (currently RDForms); `GPL-3.0` `Python`.
+- [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter" align="top"> ☠️ - Shape shifter from SHACL to other formats (currently RDForms); `GPL-3.0` license; `Python`.
 - [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/comake/shacl-to-json-schema" align="top"> - TS, SHACL-to-JSON-Schema translator; `Typescript`.
 
 ## Shape Generators
@@ -66,17 +66,17 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## Shape-based Query Generators
 
-- [@hydrofoil/shape-to-query](https://shape-to-query.hypermedia.app/docs) - Generate SPARQL queries from SHACL Shapes; [playground](https://shape-to-query.hypermedia.app); `Typescript` `MIT`.
+- [shape-to-query](https://github.com/hypermedia-app/shape-to-query) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/hypermedia-app/shape-to-query" align="top"> - Generate SPARQL queries from SHACL Shapes; [playground](https://shape-to-query.hypermedia.app); `MIT` license; `Typescript`.
 
 ## Shape Editors, Visualizations
 
-- [Allotrope Shape Editor](https://gitlab.com/allotrope-open-source/allotrope-devops/-/wikis/shacl-shape-editor) - The Shape Editor supports editing of shacl and shaclc files; `Apache-2.0` `Java`.
+- [Allotrope Shape Editor](https://gitlab.com/allotrope-open-source/allotrope-devops/-/wikis/shacl-shape-editor) - The Shape Editor supports editing of shacl and shaclc files; `Apache-2.0` license; `Java`.
 
 ## Declarative UIs
 
 Data viewers/Editors based on shapes.
 
-- [shaperone](https://forms.hypermedia.app) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/hypermedia-app/shaperone" align="top"> - SHACL Shapes Form generator; [playground](https://forms.hypermedia.app/playground); `MIT` `Typescript`.
+- [shaperone](https://github.com/hypermedia-app/shaperone) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/hypermedia-app/shaperone" align="top"> - SHACL Shapes Form generator; [playground](https://forms.hypermedia.app/playground); `MIT` license; `Typescript`.
 
 ## IDE support
 
@@ -96,6 +96,7 @@ Data viewers/Editors based on shapes.
 
 - [The Many Shapes of SHACL by Holger Knublauch](https://www.youtube.com/watch?v=ccs-KhnWR1U) - LOTICO Talk, 18 Jun 2020.
 - [One Ontology, One Data Set, Multiple Shapes with SHACL by Tara Raafat](https://www.youtube.com/watch?v=apG5K3zc4V0) - Connected Data London, 2019.
+- [An Overview of SHACL Shapes Constraint Language - Part 2](https://www.youtube.com/watch?v=TSDplfqw8rM) - TopQuadrant, 2017.
 - [An Overview of SHACL Shapes Constraint Language](https://www.youtube.com/watch?v=_i3zTeMyRzU) - TopQuadrant, 2017.
 
 ## Presentations
@@ -123,6 +124,6 @@ Data viewers/Editors based on shapes.
   - [P3330TM/D3 Draft Recommended Practice for Standard for Shape Expression Schemas](https://shexspec.github.io/spec/)
 
 ## Legend
-:skull: — Each one denotes 5 years since last update (e.g., :skull: :skull: :skull: denotes 15 years).
+☠️ — Each one denotes 5 years since last update (e.g., ☠️☠️☠️ denotes 15 years).
 
-:moneybag: — Denotes closed source commercial software.
+💰 — Denotes closed source commercial software.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,93 @@
+# Awesome Semantic Shapes [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-# Specification 'awesome-semantic-shapes'
+A curated list of Semantic Shapes resources.
 
-This is the repository for awesome-semantic-shapes. You're welcome to contribute! Let's make the Web rock our socks
-off!
+Contributions welcome! Please, read the [Contribution Guidelines](CONTRIBUTING.md) first.
+
+## Contents
+
+- [SHACL Validators](#shacl-validators)
+- [ShEx Validators](#shex-validators)
+- [Shapes Discovery Tools](#shapes-discovery-tools)
+- [Shapes Collections](#shapes-collections)
+- [Shape Conversion Tools](#shape-conversion-tools)
+- [Shape Generators](#shape-generators)
+- [Shape Editors, Visualizations](#shape-editors-visualizations)
+- [Declarative UIs](#declarative-uis)
+- [Book](#book)
+- [Tutorials](#tutorials)
+- [Presentations](#presentations)
+- [Specifications](#specifications)
+
+## SHACL Validators
+
+About this section. Optional. Keep this short and focus on the list.
+
+- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) -- Java, based on Jena, supports: SHACL Core, SHACL-SPARQL, SHACL rules
+- [Jena SHACL](https://github.com/apache/jena/) -- Java, Supports: SHACL Core, SHACL-SPARQL
+- [RDF4J SHACL Sail](https://github.com/eclipse-rdf4j/rdf4j) -- Java
+- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) -- Java, fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot
+
+## ShEx Validators
+
+- [shexSpec/shex.js](https://github.com/shexjs/shex.js) -- JS, [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html)
+- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) -- JS
+- [Validata](https://github.com/HW-SWeL/Validata) -- JS, [playground](http://hw-swel.github.io/Validata/), [playground](https://www.w3.org/2015/03/ShExValidata/)
+- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) -- Java
+
+## Shapes Discovery Tools
+
+- [Shapes of You index](https://index.semanticscience.org/) -- SPARQL queries, OWL/SKOS vocabularies, SHACL/ShEx shapes indexed from public git repositories.
+- [RDFminer](https://github.com/Wimmics/RDFminer) -- Web application to automatically discovering SHACL shapes representative of an RDF data graph, by Wimmics
+- [SHACL Discovery Service](https://github.com/AKSW/discover-shacl-shapes)
+
+## Shapes Collections
+
+- [schema.org Shapes](http://datashapes.org/schema) -- Schema.org, converted to SHACL by TopQuadrant
+
+## Shape Conversion Tools
+
+- [ShacShifter](https://github.com/AKSW/ShacShifter) -- "shape shifter" from SHACL to other formats (currently RDForms)
+
+## Shape Generators
+
+- [owl2shacl](https://github.com/sparna-git/owl2shacl) -- OWL 2 SHACL conversion rules
+
+## Shape Editors, Visualizations
+
+- [Allotrope Shape Editor](https://gitlab.com/allotrope-open-source/shape-editor)
+
+## Declarative UIs
+
+Data viewers/Editors based on shapes.
+
+- [shaperone](https://forms.hypermedia.app) -- SHACL Shapes Form generator
+
+## Book
+
+- [Validating RDF Data (2018)](https://book.validatingrdf.com/) 
+
+## Tutorials
+
+- [Shapes applications and tools - ISWC'20 Tutorial](https://www.validatingrdf.com/tutorial/iswc2020/)
+
+## Presentations
+
+## Specifications
+
+- SHACL, W3C Recommendations & Notes
+  - [Shapes Constraint Language (SHACL)](https://www.w3.org/TR/shacl/) -- W3C Recommendation, 20 July 2017
+  - [SHACL Advanced Features](https://www.w3.org/TR/shacl-af/) -- W3C Working Group Note, 08 June 2017
+  - [SHACL JavaScript Extensions](https://www.w3.org/TR/shacl-js/) -- W3C Working Group Note, 08 June 2017
+  - [SHACL Test Suite and Implementation Report](https://w3c.github.io/data-shapes/data-shapes-test-suite/) -- W3C Document 17 January 2024
+  - [SHACL Use Cases and Requirements](https://www.w3.org/TR/shacl-ucr/) -- W3C Working Group Note 20 July 2017
+- SHACL, Community Group Latest Drafts & Notes
+  - [SHACL 1.2 Core](https://w3c.github.io/shacl/shacl-core/)
+  - [SHACL 1.2 SPARQL Extensions](https://w3c.github.io/shacl/shacl-sparql/)
+  - [SHACL Advanced Features 1.1](https://w3c.github.io/shacl/shacl-af/)
+  - [SHACL Compact Syntax](https://w3c.github.io/shacl/shacl-compact-syntax/)
+  - [SHACL JavaScript Extensions](https://w3c.github.io/shacl/shacl-js/)
+- ShEx
+  - [Shape Expressions Language 2.1](https://shex.io/shex-semantics/index.html) -- Final Community Group Report 8 October 2019
+- ShEx, Drafts
+  - [P3330TM/D3 Draft Recommended Practice for Standard for Shape Expression Schemas](https://shexspec.github.io/spec/)

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ Semantic shapes could be described in SHACL or ShEx languages.
 
 ## SHACL Validators
 
-- [Jena SHACL](https://github.com/apache/jena/) - Java; Supports: SHACL Core, SHACL-SPARQL.
-- [RDF4J SHACL Sail](https://github.com/eclipse-rdf4j/rdf4j) - Java.
-- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) - Java; based on Jena; supports: SHACL Core, SHACL-SPARQL, SHACL rules.
-- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) - Java; fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot.
+- [Jena SHACL](https://github.com/apache/jena/) ![GitHub last commit](https://img.shields.io/github/last-commit/apache/jena) `Apache-2.0` `Java` - Supports: SHACL Core, SHACL-SPARQL.
+- [RDF4J SHACL Sail](https://github.com/eclipse-rdf4j/rdf4j) ![GitHub last commit](https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j) `BSD-3-Clause` `Java`
+- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) ![GitHub last commit](https://img.shields.io/github/last-commit/TopQuadrant/shacl) `BSD-3-Clause` `Java` - Based on Jena; supports: SHACL Core, SHACL-SPARQL, SHACL rules.
+- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) ![GitHub last commit](https://img.shields.io/github/last-commit/SHACL-X/shacl-x) `BSD-3-Clause` `Java` - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot.
+- [SHACL for Ruby](https://github.com/ruby-rdf/shacl/) ![GitHub last commit](https://img.shields.io/github/last-commit/ruby-rdf/shacl) `BSD-3-Clause` `Ruby` - A pure-Ruby library for working with the Shape Constraint Language to validate the shape of RDF graphs.
 
 ## ShEx Validators
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > Please, read the [Contribution Guidelines](CONTRIBUTING.md) first.
 
 Semantic shapes enable you to validate RDF graphs against a set of conditions.
-Semantic shapes can also be viewed as a description of the data graphs that do satisfy these conditions.
+Semantic shapes can also be viewed as a description of data graphs that satisfy these conditions.
 Such descriptions may be used for a variety of purposes beside validation,
 including user interface building, code generation and data integration.
 Semantic shapes could be described in SHACL or ShEx languages.
@@ -28,10 +28,10 @@ Semantic shapes could be described in SHACL or ShEx languages.
 
 ## SHACL Validators
 
-- [Jena SHACL](https://github.com/apache/jena/) - Java, Supports: SHACL Core, SHACL-SPARQL.
+- [Jena SHACL](https://github.com/apache/jena/) - Java; Supports: SHACL Core, SHACL-SPARQL.
 - [RDF4J SHACL Sail](https://github.com/eclipse-rdf4j/rdf4j) - Java.
-- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) - Java, based on Jena, supports: SHACL Core, SHACL-SPARQL, SHACL rules.
-- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) - Java, fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot.
+- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) - Java; based on Jena; supports: SHACL Core, SHACL-SPARQL, SHACL rules.
+- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) - Java; fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot.
 
 ## ShEx Validators
 
@@ -42,9 +42,9 @@ Semantic shapes could be described in SHACL or ShEx languages.
 
 ## Shapes Discovery Tools
 
-- [RDFminer](https://github.com/Wimmics/RDFminer) - Web application to automatically discovering SHACL shapes representative of an RDF data graph, by Wimmics.
+- [RDFminer](https://github.com/Wimmics/RDFminer) - Web application to automatically discover SHACL shapes representative of an RDF data graph, by Wimmics.
 - [SHACL Discovery Service](https://github.com/AKSW/discover-shacl-shapes)
-- [Shapes of You index](https://index.semanticscience.org/) - SPARQL queries, OWL/SKOS vocabularies, SHACL/ShEx shapes indexed from public git repositories.
+- [Shapes of You index](https://index.semanticscience.org/) - SPARQL queries, OWL/SKOS vocabularies, SHACL/ShEx shapes, indexed from public `git` repositories.
 
 ## Shapes Collections
 
@@ -53,11 +53,11 @@ Semantic shapes could be described in SHACL or ShEx languages.
 ## Shape Conversion Tools
 
 - [ShacShifter](https://github.com/AKSW/ShacShifter) - Python, ☠️, "shape shifter" from SHACL to other formats (currently RDForms).
-- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) - TS, SHACL To JSON Schema translator.
+- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) - TS, SHACL-to-JSON-Schema translator.
 
 ## Shape Generators
 
-- [owl2shacl](https://github.com/sparna-git/owl2shacl) - OWL 2 SHACL conversion rules.
+- [owl2shacl](https://github.com/sparna-git/owl2shacl) - OWL-to-SHACL conversion rules.
 
 ## Shape Editors, Visualizations
 
@@ -71,7 +71,7 @@ Data viewers/Editors based on shapes.
 
 ## IDE support
 
-- [Linked Data Extension](https://github.com/elsevierlabs-os/linked-data) - VS Code Extension for RDF files editing with embedded SHACL validator and SPARQL engine.
+- [Linked Data Extension](https://github.com/elsevierlabs-os/linked-data) - VS Code Extension for editing RDF files with embedded SHACL validator and SPARQL engine.
 
 ## Book
 
@@ -106,5 +106,5 @@ Data viewers/Editors based on shapes.
   - [P3330TM/D3 Draft Recommended Practice for Standard for Shape Expression Schemas](https://shexspec.github.io/spec/)
 
 ## Legend
-☠️ -- Each one denotes every 5 year from last update.
-💰 -- Denotes closed source commercial software.
+☠️ — Each one denotes 5 years (e.g., ☠️☠️☠️ denotes 15 years) since last update.
+💰 — Denotes closed source commercial software.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Awesome Semantic Shapes [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-A curated list of Semantic Shapes resources.
+> A curated list of Semantic Shapes resources. Contributions welcome! Please, read the [Contribution Guidelines](CONTRIBUTING.md) first.
 
-Contributions welcome! Please, read the [Contribution Guidelines](CONTRIBUTING.md) first.
+Semantic shapes enables you to validate RDF graphs against a set of conditions. Semantic shapes can also be viewed as a description of the data graphs that do satisfy these conditions. Such descriptions may be used for a variety of purposes beside validation, including user interface building, code generation and data integration. Semantic shapes could be described in SHACL or ShEx languages.
 
 ## Contents
 
@@ -18,28 +18,27 @@ Contributions welcome! Please, read the [Contribution Guidelines](CONTRIBUTING.m
 - [Tutorials](#tutorials)
 - [Presentations](#presentations)
 - [Specifications](#specifications)
+- [Legend](#legend)
 
 ## SHACL Validators
 
-About this section. Optional. Keep this short and focus on the list.
-
-- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) -- Java, based on Jena, supports: SHACL Core, SHACL-SPARQL, SHACL rules
 - [Jena SHACL](https://github.com/apache/jena/) -- Java, Supports: SHACL Core, SHACL-SPARQL
 - [RDF4J SHACL Sail](https://github.com/eclipse-rdf4j/rdf4j) -- Java
+- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) -- Java, based on Jena, supports: SHACL Core, SHACL-SPARQL, SHACL rules
 - [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) -- Java, fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot
 
 ## ShEx Validators
 
+- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) -- Java
 - [shexSpec/shex.js](https://github.com/shexjs/shex.js) -- JS, [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html)
 - [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) -- JS
 - [Validata](https://github.com/HW-SWeL/Validata) -- JS, [playground](http://hw-swel.github.io/Validata/), [playground](https://www.w3.org/2015/03/ShExValidata/)
-- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) -- Java
 
 ## Shapes Discovery Tools
 
-- [Shapes of You index](https://index.semanticscience.org/) -- SPARQL queries, OWL/SKOS vocabularies, SHACL/ShEx shapes indexed from public git repositories.
 - [RDFminer](https://github.com/Wimmics/RDFminer) -- Web application to automatically discovering SHACL shapes representative of an RDF data graph, by Wimmics
 - [SHACL Discovery Service](https://github.com/AKSW/discover-shacl-shapes)
+- [Shapes of You index](https://index.semanticscience.org/) -- SPARQL queries, OWL/SKOS vocabularies, SHACL/ShEx shapes indexed from public git repositories.
 
 ## Shapes Collections
 
@@ -47,7 +46,8 @@ About this section. Optional. Keep this short and focus on the list.
 
 ## Shape Conversion Tools
 
-- [ShacShifter](https://github.com/AKSW/ShacShifter) -- "shape shifter" from SHACL to other formats (currently RDForms)
+- [ShacShifter](https://github.com/AKSW/ShacShifter) -- Python, ☠️, "shape shifter" from SHACL to other formats (currently RDForms)
+- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) -- TS, SHACL To JSON Schema translator
 
 ## Shape Generators
 
@@ -91,3 +91,7 @@ Data viewers/Editors based on shapes.
   - [Shape Expressions Language 2.1](https://shex.io/shex-semantics/index.html) -- Final Community Group Report 8 October 2019
 - ShEx, Drafts
   - [P3330TM/D3 Draft Recommended Practice for Standard for Shape Expression Schemas](https://shexspec.github.io/spec/)
+
+## Legend
+☠️ -- each one denotes every 5 year from last update
+💰 -- denotes closed source commercial software

--- a/README.md
+++ b/README.md
@@ -30,20 +30,20 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## SHACL Validators
 
-- [Apache Jena SHACL](https://jena.apache.org/documentation/shacl/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="middle"> - Supports SHACL Core, SHACL-SPARQL; `Apache-2.0` `Java`.
-- [RDF4J SHACL Engine](https://rdf4j.org/documentation/programming/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j" align="middle"> - Supports SHACL Core (without some property paths), SHACL-SPARQL, incremental validation; `BSD-3-Clause` `Java`.
-- [rdf-validate-shacl](https://github.com/zazuko/rdf-validate-shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/zazuko/rdf-validate-shacl" align="middle"> - Supports SHACL Core; pure JavaScript validator on top of the [RDFJS](https://rdf.js.org/) stack; [playground](https://zazuko.github.io/shacl-playground); `MIT` `JavaScript`.
+- [Apache Jena SHACL](https://jena.apache.org/documentation/shacl/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="bottom"> - Supports SHACL Core, SHACL-SPARQL; `Apache-2.0` `Java`.
+- [RDF4J SHACL Engine](https://rdf4j.org/documentation/programming/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j" align="bottom"> - Supports SHACL Core (without some property paths), SHACL-SPARQL, incremental validation; `BSD-3-Clause` `Java`.
+- [rdf-validate-shacl](https://github.com/zazuko/rdf-validate-shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/zazuko/rdf-validate-shacl" align="bottom"> - Supports SHACL Core; pure JavaScript validator on top of the [RDFJS](https://rdf.js.org/) stack; [playground](https://zazuko.github.io/shacl-playground); `MIT` `JavaScript`.
 - [SHACL for Ruby](https://github.com/ruby-rdf/shacl/) ![GitHub last commit](https://img.shields.io/github/last-commit/ruby-rdf/shacl) - A pure-Ruby library for working with the Shape Constraint Language to validate the shape of RDF graphs; `BSD-3-Clause` `Ruby`.
-- [shacl-engine](https://github.com/rdf-ext/shacl-engine) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/rdf-ext/shacl-engine" align="middle"> - Supports SHACL Core, SHACL-SPARQL; A fast engine for data provided as [RDF/JS](http://rdf.js.org/data-model-spec/) objects; [playground](https://playground.rdf-ext.org/shacl/); `MIT` `JavaScript`.
-- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/TopQuadrant/shacl" align="middle"> - Supports SHACL Core, SHACL-SPARQL, SHACL rules; based on Jena; `BSD-3-Clause` `Java`.
-- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/SHACL-X/shacl-x" align="middle"> - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot; `BSD-3-Clause` `Java`.
+- [shacl-engine](https://github.com/rdf-ext/shacl-engine) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/rdf-ext/shacl-engine" align="bottom"> - Supports SHACL Core, SHACL-SPARQL; A fast engine for data provided as [RDF/JS](http://rdf.js.org/data-model-spec/) objects; [playground](https://playground.rdf-ext.org/shacl/); `MIT` `JavaScript`.
+- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/TopQuadrant/shacl" align="bottom"> - Supports SHACL Core, SHACL-SPARQL, SHACL rules; based on Jena; `BSD-3-Clause` `Java`.
+- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/SHACL-X/shacl-x" align="bottom"> - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot; `BSD-3-Clause` `Java`.
 
 ## ShEx Validators
 
-- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="middle"> - Supports ShEx, ShExC; not supported semantic actions, EXTERNAL; `Apache-2.0` `Java`.
-- [shexSpec/shex.js](https://github.com/shexjs/shex.js) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="middle"> - JavaScript implementation of Shape Expressions; [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html); `MIT` `JavaScript`.
-- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator" align="middle"> :skull: - A standalone Node module with a command line interface; `MIT` `JavaScript`.
-- [Validata](https://github.com/HW-SWeL/Validata) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata" align="middle"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground](http://hw-swel.github.io/Validata/); [playground](https://www.w3.org/2015/03/ShExValidata/); `MIT` `JavaScript`.
+- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="bottom"> - Supports ShEx, ShExC; not supported semantic actions, EXTERNAL; `Apache-2.0` `Java`.
+- [shexSpec/shex.js](https://github.com/shexjs/shex.js) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="bottom"> - JavaScript implementation of Shape Expressions; [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html); `MIT` `JavaScript`.
+- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator" align="bottom"> :skull: - A standalone Node module with a command line interface; `MIT` `JavaScript`.
+- [Validata](https://github.com/HW-SWeL/Validata) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata" align="bottom"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground](http://hw-swel.github.io/Validata/); [playground](https://www.w3.org/2015/03/ShExValidata/); `MIT` `JavaScript`.
 
 ## Shapes Discovery Tools
 
@@ -57,8 +57,8 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## Shape Conversion Tools
 
-- [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter" align="middle"> :skull: - Shape shifter from SHACL to other formats (currently RDForms); `GPL-3.0` `Python`.
-- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/comake/shacl-to-json-schema" align="middle"> - TS, SHACL-to-JSON-Schema translator; `Typescript`.
+- [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter" align="bottom"> :skull: - Shape shifter from SHACL to other formats (currently RDForms); `GPL-3.0` `Python`.
+- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/comake/shacl-to-json-schema" align="bottom"> - TS, SHACL-to-JSON-Schema translator; `Typescript`.
 
 ## Shape Generators
 
@@ -76,7 +76,7 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 Data viewers/Editors based on shapes.
 
-- [shaperone](https://forms.hypermedia.app) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/hypermedia-app/shaperone" align="middle"> - SHACL Shapes Form generator; [playground](https://forms.hypermedia.app/playground); `MIT` `Typescript`.
+- [shaperone](https://forms.hypermedia.app) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/hypermedia-app/shaperone" align="bottom"> - SHACL Shapes Form generator; [playground](https://forms.hypermedia.app/playground); `MIT` `Typescript`.
 
 ## IDE support
 

--- a/README.md
+++ b/README.md
@@ -29,24 +29,26 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## SHACL Validators
 
-- [Apache Jena SHACL](https://github.com/apache/jena/) ![GitHub last commit](https://img.shields.io/github/last-commit/apache/jena) `Apache-2.0` `Java` - Supports: SHACL Core, SHACL-SPARQL.
-- [RDF4J SHACL Engine](https://github.com/eclipse-rdf4j/rdf4j) ![GitHub last commit](https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j) - Supports SHACL Core (without some property paths), SHACL-SPARQL, incremental validation; `BSD-3-Clause` `Java`.
-- [SHACL for Ruby](https://github.com/ruby-rdf/shacl/) ![GitHub last commit](https://img.shields.io/github/last-commit/ruby-rdf/shacl) `BSD-3-Clause` `Ruby` - A pure-Ruby library for working with the Shape Constraint Language to validate the shape of RDF graphs.
-- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) ![GitHub last commit](https://img.shields.io/github/last-commit/TopQuadrant/shacl) `BSD-3-Clause` `Java` - Based on Jena; supports: SHACL Core, SHACL-SPARQL, SHACL rules.
-- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) ![GitHub last commit](https://img.shields.io/github/last-commit/SHACL-X/shacl-x) `BSD-3-Clause` `Java` - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot.
+- [Apache Jena SHACL](https://jena.apache.org/documentation/shacl/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - Supports SHACL Core, SHACL-SPARQL; `Apache-2.0` `Java`.
+- [RDF4J SHACL Engine](https://rdf4j.org/documentation/programming/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j" align="top"> - Supports SHACL Core (without some property paths), SHACL-SPARQL, incremental validation; `BSD-3-Clause` `Java`.
+- [rdf-validate-shacl](https://github.com/zazuko/rdf-validate-shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/zazuko/rdf-validate-shacl" align="top"> - Supports SHACL Core; pure JavaScript validator on top of the [RDFJS](https://rdf.js.org/) stack; [playground](https://zazuko.github.io/shacl-playground); `MIT` `JavaScript`.
+- [SHACL for Ruby](https://github.com/ruby-rdf/shacl/) ![GitHub last commit](https://img.shields.io/github/last-commit/ruby-rdf/shacl) - A pure-Ruby library for working with the Shape Constraint Language to validate the shape of RDF graphs; `BSD-3-Clause` `Ruby`.
+- [shacl-engine](https://github.com/rdf-ext/shacl-engine) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/rdf-ext/shacl-engine" align="top"> - Supports SHACL Core, SHACL-SPARQL; A fast engine for data provided as [RDF/JS](http://rdf.js.org/data-model-spec/) objects; [playground](https://playground.rdf-ext.org/shacl/); `MIT` `JavaScript`.
+- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/TopQuadrant/shacl" align="top"> - Supports SHACL Core, SHACL-SPARQL, SHACL rules; based on Jena; `BSD-3-Clause` `Java`.
+- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/SHACL-X/shacl-x" align="top"> - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot; `BSD-3-Clause` `Java`.
 
 ## ShEx Validators
 
-- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) - Java.
-- [shexSpec/shex.js](https://github.com/shexjs/shex.js) - [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html) - JS.
-- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) - JS.
-- [Validata](https://github.com/HW-SWeL/Validata) - [playground](http://hw-swel.github.io/Validata/) - [playground](https://www.w3.org/2015/03/ShExValidata/), JS.
+- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - `Apache-2.0` `Java`.
+- [shexSpec/shex.js](https://github.com/shexjs/shex.js)<img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="top"> - [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html) - `MIT` `JavaScript`.
+- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator)<img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator" align="top"> - :skull:  `MIT` `JavaScript`.
+- [Validata](https://github.com/HW-SWeL/Validata)<img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata" align="top"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground](http://hw-swel.github.io/Validata/); [playground](https://www.w3.org/2015/03/ShExValidata/); `MIT` `JavaScript`.
 
 ## Shapes Discovery Tools
 
-- [RDFminer](https://github.com/Wimmics/RDFminer) - Web application to automatically discover SHACL shapes representative of an RDF data graph, by Wimmics.
-- [SHACL Discovery Service](https://github.com/AKSW/discover-shacl-shapes)
-- [Shapes of You index](https://index.semanticscience.org/) - SPARQL queries, OWL/SKOS vocabularies, SHACL/ShEx shapes, indexed from public `git` repositories.
+- [RDFminer](https://github.com/Wimmics/RDFminer) - Web application to automatically discover SHACL shapes representative of an RDF data graph, by Wimmics; `CECILL-C` `Java`.
+- [SHACL Discovery Service](https://github.com/AKSW/discover-shacl-shapes) - Example implementation of a discovery service for SHACL shapes/shape groups; `MIT` `PHP`.
+- [Shapes of You index](https://index.semanticscience.org/) - SPARQL queries, OWL/SKOS vocabularies, SHACL/ShEx shapes, indexed from public `git` repositories; `MIT` `Typescript, Python`.
 
 ## Shapes Collections
 
@@ -54,8 +56,8 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## Shape Conversion Tools
 
-- [ShacShifter](https://github.com/AKSW/ShacShifter) - Python, ☠️, "shape shifter" from SHACL to other formats (currently RDForms).
-- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) - TS, SHACL-to-JSON-Schema translator.
+- [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter" align="top"> - :skull: "shape shifter" from SHACL to other formats (currently RDForms); `GPL-3.0` `Python`.
+- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/comake/shacl-to-json-schema" align="top"> - TS, SHACL-to-JSON-Schema translator; `Typescript`.
 
 ## Shape Generators
 
@@ -63,17 +65,17 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## Shape-based Query Generators
 
-- [@hydrofoil/shape-to-query](https://github.com/hypermedia-app/shape-to-query) [docs](https://shape-to-query.hypermedia.app/docs/#extension-spo-rule) - Generate SPARQL queries from SHACL Shapes.
+- [@hydrofoil/shape-to-query](https://shape-to-query.hypermedia.app/docs) - Generate SPARQL queries from SHACL Shapes; [playground](https://shape-to-query.hypermedia.app); `Typescript` `MIT`.
 
 ## Shape Editors, Visualizations
 
-- [Allotrope Shape Editor](https://gitlab.com/allotrope-open-source/shape-editor)
+- [Allotrope Shape Editor](https://gitlab.com/allotrope-open-source/allotrope-devops/-/wikis/shacl-shape-editor) - The Shape Editor supports editing of shacl and shaclc files; `Apache-2.0` `Java`.
 
 ## Declarative UIs
 
 Data viewers/Editors based on shapes.
 
-- [shaperone](https://forms.hypermedia.app) - SHACL Shapes Form generator.
+- [shaperone](https://forms.hypermedia.app) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/hypermedia-app/shaperone" align="top"> - SHACL Shapes Form generator; [playground](https://forms.hypermedia.app/playground); `MIT` `Typescript`.
 
 ## IDE support
 
@@ -112,5 +114,6 @@ Data viewers/Editors based on shapes.
   - [P3330TM/D3 Draft Recommended Practice for Standard for Shape Expression Schemas](https://shexspec.github.io/spec/)
 
 ## Legend
-☠️ — Each one denotes 5 years (e.g., ☠️☠️☠️ denotes 15 years) since last update.
-💰 — Denotes closed source commercial software.
+:skull: — Each one denotes 5 years since last update (e.g., :skull: :skull: :skull: denotes 15 years).
+
+:moneybag: — Denotes closed source commercial software.

--- a/README.md
+++ b/README.md
@@ -30,20 +30,20 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## SHACL Validators
 
-- [Apache Jena SHACL](https://jena.apache.org/documentation/shacl/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - Supports SHACL Core, SHACL-SPARQL; `Apache-2.0` `Java`.
-- [RDF4J SHACL Engine](https://rdf4j.org/documentation/programming/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j" align="top"> - Supports SHACL Core (without some property paths), SHACL-SPARQL, incremental validation; `BSD-3-Clause` `Java`.
-- [rdf-validate-shacl](https://github.com/zazuko/rdf-validate-shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/zazuko/rdf-validate-shacl" align="top"> - Supports SHACL Core; pure JavaScript validator on top of the [RDFJS](https://rdf.js.org/) stack; [playground](https://zazuko.github.io/shacl-playground); `MIT` `JavaScript`.
+- [Apache Jena SHACL](https://jena.apache.org/documentation/shacl/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="middle"> - Supports SHACL Core, SHACL-SPARQL; `Apache-2.0` `Java`.
+- [RDF4J SHACL Engine](https://rdf4j.org/documentation/programming/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j" align="middle"> - Supports SHACL Core (without some property paths), SHACL-SPARQL, incremental validation; `BSD-3-Clause` `Java`.
+- [rdf-validate-shacl](https://github.com/zazuko/rdf-validate-shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/zazuko/rdf-validate-shacl" align="middle"> - Supports SHACL Core; pure JavaScript validator on top of the [RDFJS](https://rdf.js.org/) stack; [playground](https://zazuko.github.io/shacl-playground); `MIT` `JavaScript`.
 - [SHACL for Ruby](https://github.com/ruby-rdf/shacl/) ![GitHub last commit](https://img.shields.io/github/last-commit/ruby-rdf/shacl) - A pure-Ruby library for working with the Shape Constraint Language to validate the shape of RDF graphs; `BSD-3-Clause` `Ruby`.
-- [shacl-engine](https://github.com/rdf-ext/shacl-engine) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/rdf-ext/shacl-engine" align="top"> - Supports SHACL Core, SHACL-SPARQL; A fast engine for data provided as [RDF/JS](http://rdf.js.org/data-model-spec/) objects; [playground](https://playground.rdf-ext.org/shacl/); `MIT` `JavaScript`.
-- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/TopQuadrant/shacl" align="top"> - Supports SHACL Core, SHACL-SPARQL, SHACL rules; based on Jena; `BSD-3-Clause` `Java`.
-- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/SHACL-X/shacl-x" align="top"> - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot; `BSD-3-Clause` `Java`.
+- [shacl-engine](https://github.com/rdf-ext/shacl-engine) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/rdf-ext/shacl-engine" align="middle"> - Supports SHACL Core, SHACL-SPARQL; A fast engine for data provided as [RDF/JS](http://rdf.js.org/data-model-spec/) objects; [playground](https://playground.rdf-ext.org/shacl/); `MIT` `JavaScript`.
+- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/TopQuadrant/shacl" align="middle"> - Supports SHACL Core, SHACL-SPARQL, SHACL rules; based on Jena; `BSD-3-Clause` `Java`.
+- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/SHACL-X/shacl-x" align="middle"> - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot; `BSD-3-Clause` `Java`.
 
 ## ShEx Validators
 
-- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - Supports ShEx, ShExC; not supported semantic actions, EXTERNAL; `Apache-2.0` `Java`.
-- [shexSpec/shex.js](https://github.com/shexjs/shex.js) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="top"> - JavaScript implementation of Shape Expressions; [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html); `MIT` `JavaScript`.
-- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator" align="top"> :skull: - A standalone Node module with a command line interface; `MIT` `JavaScript`.
-- [Validata](https://github.com/HW-SWeL/Validata) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata" align="top"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground](http://hw-swel.github.io/Validata/); [playground](https://www.w3.org/2015/03/ShExValidata/); `MIT` `JavaScript`.
+- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="middle"> - Supports ShEx, ShExC; not supported semantic actions, EXTERNAL; `Apache-2.0` `Java`.
+- [shexSpec/shex.js](https://github.com/shexjs/shex.js) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="middle"> - JavaScript implementation of Shape Expressions; [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html); `MIT` `JavaScript`.
+- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator" align="middle"> :skull: - A standalone Node module with a command line interface; `MIT` `JavaScript`.
+- [Validata](https://github.com/HW-SWeL/Validata) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata" align="middle"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground](http://hw-swel.github.io/Validata/); [playground](https://www.w3.org/2015/03/ShExValidata/); `MIT` `JavaScript`.
 
 ## Shapes Discovery Tools
 
@@ -57,8 +57,8 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## Shape Conversion Tools
 
-- [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter" align="top"> :skull: - Shape shifter from SHACL to other formats (currently RDForms); `GPL-3.0` `Python`.
-- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/comake/shacl-to-json-schema" align="top"> - TS, SHACL-to-JSON-Schema translator; `Typescript`.
+- [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter" align="middle"> :skull: - Shape shifter from SHACL to other formats (currently RDForms); `GPL-3.0` `Python`.
+- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/comake/shacl-to-json-schema" align="middle"> - TS, SHACL-to-JSON-Schema translator; `Typescript`.
 
 ## Shape Generators
 
@@ -76,7 +76,7 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 Data viewers/Editors based on shapes.
 
-- [shaperone](https://forms.hypermedia.app) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/hypermedia-app/shaperone" align="top"> - SHACL Shapes Form generator; [playground](https://forms.hypermedia.app/playground); `MIT` `Typescript`.
+- [shaperone](https://forms.hypermedia.app) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/hypermedia-app/shaperone" align="middle"> - SHACL Shapes Form generator; [playground](https://forms.hypermedia.app/playground); `MIT` `Typescript`.
 
 ## IDE support
 

--- a/README.md
+++ b/README.md
@@ -30,20 +30,20 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## SHACL Validators
 
-- [Apache Jena SHACL](https://jena.apache.org/documentation/shacl/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena"> - Supports SHACL Core, SHACL-SPARQL; `Apache-2.0` `Java`.
-- [RDF4J SHACL Engine](https://rdf4j.org/documentation/programming/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j"> - Supports SHACL Core (without some property paths), SHACL-SPARQL, incremental validation; `BSD-3-Clause` `Java`.
-- [rdf-validate-shacl](https://github.com/zazuko/rdf-validate-shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/zazuko/rdf-validate-shacl"> - Supports SHACL Core; pure JavaScript validator on top of the [RDFJS](https://rdf.js.org/) stack; [playground](https://zazuko.github.io/shacl-playground); `MIT` `JavaScript`.
+- [Apache Jena SHACL](https://jena.apache.org/documentation/shacl/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - Supports SHACL Core, SHACL-SPARQL; `Apache-2.0` `Java`.
+- [RDF4J SHACL Engine](https://rdf4j.org/documentation/programming/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j" align="top"> - Supports SHACL Core (without some property paths), SHACL-SPARQL, incremental validation; `BSD-3-Clause` `Java`.
+- [rdf-validate-shacl](https://github.com/zazuko/rdf-validate-shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/zazuko/rdf-validate-shacl" align="top"> - Supports SHACL Core; pure JavaScript validator on top of the [RDFJS](https://rdf.js.org/) stack; [playground](https://zazuko.github.io/shacl-playground); `MIT` `JavaScript`.
 - [SHACL for Ruby](https://github.com/ruby-rdf/shacl/) ![GitHub last commit](https://img.shields.io/github/last-commit/ruby-rdf/shacl) - A pure-Ruby library for working with the Shape Constraint Language to validate the shape of RDF graphs; `BSD-3-Clause` `Ruby`.
-- [shacl-engine](https://github.com/rdf-ext/shacl-engine) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/rdf-ext/shacl-engine"> - Supports SHACL Core, SHACL-SPARQL; A fast engine for data provided as [RDF/JS](http://rdf.js.org/data-model-spec/) objects; [playground](https://playground.rdf-ext.org/shacl/); `MIT` `JavaScript`.
-- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/TopQuadrant/shacl"> - Supports SHACL Core, SHACL-SPARQL, SHACL rules; based on Jena; `BSD-3-Clause` `Java`.
-- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/SHACL-X/shacl-x"> - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot; `BSD-3-Clause` `Java`.
+- [shacl-engine](https://github.com/rdf-ext/shacl-engine) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/rdf-ext/shacl-engine" align="top"> - Supports SHACL Core, SHACL-SPARQL; A fast engine for data provided as [RDF/JS](http://rdf.js.org/data-model-spec/) objects; [playground](https://playground.rdf-ext.org/shacl/); `MIT` `JavaScript`.
+- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/TopQuadrant/shacl" align="top"> - Supports SHACL Core, SHACL-SPARQL, SHACL rules; based on Jena; `BSD-3-Clause` `Java`.
+- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/SHACL-X/shacl-x" align="top"> - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot; `BSD-3-Clause` `Java`.
 
 ## ShEx Validators
 
-- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena"> - Supports ShEx, ShExC; not supported semantic actions, EXTERNAL; `Apache-2.0` `Java`.
-- [shexSpec/shex.js](https://github.com/shexjs/shex.js) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js"> - JavaScript implementation of Shape Expressions; [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html); `MIT` `JavaScript`.
-- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator"> :skull: - A standalone Node module with a command line interface; `MIT` `JavaScript`.
-- [Validata](https://github.com/HW-SWeL/Validata) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground](http://hw-swel.github.io/Validata/); [playground](https://www.w3.org/2015/03/ShExValidata/); `MIT` `JavaScript`.
+- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - Supports ShEx, ShExC; not supported semantic actions, EXTERNAL; `Apache-2.0` `Java`.
+- [shexSpec/shex.js](https://github.com/shexjs/shex.js) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="top"> - JavaScript implementation of Shape Expressions; [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html); `MIT` `JavaScript`.
+- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator" align="top"> :skull: - A standalone Node module with a command line interface; `MIT` `JavaScript`.
+- [Validata](https://github.com/HW-SWeL/Validata) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata" align="top"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground](http://hw-swel.github.io/Validata/); [playground](https://www.w3.org/2015/03/ShExValidata/); `MIT` `JavaScript`.
 
 ## Shapes Discovery Tools
 
@@ -57,8 +57,8 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## Shape Conversion Tools
 
-- [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter"> :skull: - Shape shifter from SHACL to other formats (currently RDForms); `GPL-3.0` `Python`.
-- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/comake/shacl-to-json-schema"> - TS, SHACL-to-JSON-Schema translator; `Typescript`.
+- [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter" align="top"> :skull: - Shape shifter from SHACL to other formats (currently RDForms); `GPL-3.0` `Python`.
+- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/comake/shacl-to-json-schema" align="top"> - TS, SHACL-to-JSON-Schema translator; `Typescript`.
 
 ## Shape Generators
 
@@ -76,7 +76,7 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 Data viewers/Editors based on shapes.
 
-- [shaperone](https://forms.hypermedia.app) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/hypermedia-app/shaperone"> - SHACL Shapes Form generator; [playground](https://forms.hypermedia.app/playground); `MIT` `Typescript`.
+- [shaperone](https://forms.hypermedia.app) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/hypermedia-app/shaperone" align="top"> - SHACL Shapes Form generator; [playground](https://forms.hypermedia.app/playground); `MIT` `Typescript`.
 
 ## IDE support
 

--- a/README.md
+++ b/README.md
@@ -30,20 +30,20 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## SHACL Validators
 
-- [Apache Jena SHACL](https://jena.apache.org/documentation/shacl/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="bottom"> - Supports SHACL Core, SHACL-SPARQL; `Apache-2.0` `Java`.
-- [RDF4J SHACL Engine](https://rdf4j.org/documentation/programming/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j" align="bottom"> - Supports SHACL Core (without some property paths), SHACL-SPARQL, incremental validation; `BSD-3-Clause` `Java`.
-- [rdf-validate-shacl](https://github.com/zazuko/rdf-validate-shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/zazuko/rdf-validate-shacl" align="bottom"> - Supports SHACL Core; pure JavaScript validator on top of the [RDFJS](https://rdf.js.org/) stack; [playground](https://zazuko.github.io/shacl-playground); `MIT` `JavaScript`.
+- [Apache Jena SHACL](https://jena.apache.org/documentation/shacl/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena"> - Supports SHACL Core, SHACL-SPARQL; `Apache-2.0` `Java`.
+- [RDF4J SHACL Engine](https://rdf4j.org/documentation/programming/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j"> - Supports SHACL Core (without some property paths), SHACL-SPARQL, incremental validation; `BSD-3-Clause` `Java`.
+- [rdf-validate-shacl](https://github.com/zazuko/rdf-validate-shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/zazuko/rdf-validate-shacl"> - Supports SHACL Core; pure JavaScript validator on top of the [RDFJS](https://rdf.js.org/) stack; [playground](https://zazuko.github.io/shacl-playground); `MIT` `JavaScript`.
 - [SHACL for Ruby](https://github.com/ruby-rdf/shacl/) ![GitHub last commit](https://img.shields.io/github/last-commit/ruby-rdf/shacl) - A pure-Ruby library for working with the Shape Constraint Language to validate the shape of RDF graphs; `BSD-3-Clause` `Ruby`.
-- [shacl-engine](https://github.com/rdf-ext/shacl-engine) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/rdf-ext/shacl-engine" align="bottom"> - Supports SHACL Core, SHACL-SPARQL; A fast engine for data provided as [RDF/JS](http://rdf.js.org/data-model-spec/) objects; [playground](https://playground.rdf-ext.org/shacl/); `MIT` `JavaScript`.
-- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/TopQuadrant/shacl" align="bottom"> - Supports SHACL Core, SHACL-SPARQL, SHACL rules; based on Jena; `BSD-3-Clause` `Java`.
-- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/SHACL-X/shacl-x" align="bottom"> - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot; `BSD-3-Clause` `Java`.
+- [shacl-engine](https://github.com/rdf-ext/shacl-engine) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/rdf-ext/shacl-engine"> - Supports SHACL Core, SHACL-SPARQL; A fast engine for data provided as [RDF/JS](http://rdf.js.org/data-model-spec/) objects; [playground](https://playground.rdf-ext.org/shacl/); `MIT` `JavaScript`.
+- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/TopQuadrant/shacl"> - Supports SHACL Core, SHACL-SPARQL, SHACL rules; based on Jena; `BSD-3-Clause` `Java`.
+- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/SHACL-X/shacl-x"> - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot; `BSD-3-Clause` `Java`.
 
 ## ShEx Validators
 
-- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="bottom"> - Supports ShEx, ShExC; not supported semantic actions, EXTERNAL; `Apache-2.0` `Java`.
-- [shexSpec/shex.js](https://github.com/shexjs/shex.js) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="bottom"> - JavaScript implementation of Shape Expressions; [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html); `MIT` `JavaScript`.
-- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator" align="bottom"> :skull: - A standalone Node module with a command line interface; `MIT` `JavaScript`.
-- [Validata](https://github.com/HW-SWeL/Validata) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata" align="bottom"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground](http://hw-swel.github.io/Validata/); [playground](https://www.w3.org/2015/03/ShExValidata/); `MIT` `JavaScript`.
+- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena"> - Supports ShEx, ShExC; not supported semantic actions, EXTERNAL; `Apache-2.0` `Java`.
+- [shexSpec/shex.js](https://github.com/shexjs/shex.js) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js"> - JavaScript implementation of Shape Expressions; [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html); `MIT` `JavaScript`.
+- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator"> :skull: - A standalone Node module with a command line interface; `MIT` `JavaScript`.
+- [Validata](https://github.com/HW-SWeL/Validata) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground](http://hw-swel.github.io/Validata/); [playground](https://www.w3.org/2015/03/ShExValidata/); `MIT` `JavaScript`.
 
 ## Shapes Discovery Tools
 
@@ -57,8 +57,8 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## Shape Conversion Tools
 
-- [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter" align="bottom"> :skull: - Shape shifter from SHACL to other formats (currently RDForms); `GPL-3.0` `Python`.
-- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/comake/shacl-to-json-schema" align="bottom"> - TS, SHACL-to-JSON-Schema translator; `Typescript`.
+- [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter"> :skull: - Shape shifter from SHACL to other formats (currently RDForms); `GPL-3.0` `Python`.
+- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/comake/shacl-to-json-schema"> - TS, SHACL-to-JSON-Schema translator; `Typescript`.
 
 ## Shape Generators
 
@@ -76,7 +76,7 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 Data viewers/Editors based on shapes.
 
-- [shaperone](https://forms.hypermedia.app) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/hypermedia-app/shaperone" align="bottom"> - SHACL Shapes Form generator; [playground](https://forms.hypermedia.app/playground); `MIT` `Typescript`.
+- [shaperone](https://forms.hypermedia.app) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/hypermedia-app/shaperone"> - SHACL Shapes Form generator; [playground](https://forms.hypermedia.app/playground); `MIT` `Typescript`.
 
 ## IDE support
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## ShEx Validators
 
-- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - `Apache-2.0` `Java`.
-- [shexSpec/shex.js](https://github.com/shexjs/shex.js)<img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="top"> - [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html); `MIT` `JavaScript`.
-- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator)<img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator" align="top"> - :skull:  `MIT` `JavaScript`.
-- [Validata](https://github.com/HW-SWeL/Validata)<img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata" align="top"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground](http://hw-swel.github.io/Validata/); [playground](https://www.w3.org/2015/03/ShExValidata/); `MIT` `JavaScript`.
+- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - Supports ShEx, ShExC; not supported semantic actions, EXTERNAL; `Apache-2.0` `Java`.
+- [shexSpec/shex.js](https://github.com/shexjs/shex.js) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="top"> - JavaScript implementation of Shape Expressions; [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html); `MIT` `JavaScript`.
+- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator" align="top"> - A standalone Node module with a command line interface; :skull: `MIT` `JavaScript`.
+- [Validata](https://github.com/HW-SWeL/Validata) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata" align="top"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground](http://hw-swel.github.io/Validata/); [playground](https://www.w3.org/2015/03/ShExValidata/); `MIT` `JavaScript`.
 
 ## Shapes Discovery Tools
 
@@ -57,7 +57,7 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## Shape Conversion Tools
 
-- [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter" align="top"> - :skull: "shape shifter" from SHACL to other formats (currently RDForms); `GPL-3.0` `Python`.
+- [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter" align="top"> - Shape shifter from SHACL to other formats (currently RDForms); :skull: `GPL-3.0` `Python`.
 - [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/comake/shacl-to-json-schema" align="top"> - TS, SHACL-to-JSON-Schema translator; `Typescript`.
 
 ## Shape Generators

--- a/README.md
+++ b/README.md
@@ -30,20 +30,29 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## SHACL Validators
 
-- [Apache Jena SHACL](https://github.com/apache/jena/tree/main/jena-shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - Supports SHACL Core, SHACL-SPARQL; `Apache-2.0` license; `Java`.
-- [RDF4J SHACL Engine](https://github.com/eclipse-rdf4j/rdf4j/tree/main/core/sail/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/eclipse-rdf4j/rdf4j" align="top"> - Supports SHACL Core (without some property paths), SHACL-SPARQL, incremental validation; `BSD-3-Clause` license; `Java`.
-- [rdf-validate-shacl](https://github.com/zazuko/rdf-validate-shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/zazuko/rdf-validate-shacl" align="top"> - Supports SHACL Core; pure JavaScript validator on top of the [RDFJS](https://rdf.js.org/) stack; [playground](https://zazuko.github.io/shacl-playground); `MIT` license; `JavaScript`.
-- [SHACL for Ruby](https://github.com/ruby-rdf/shacl) ![GitHub last commit](https://img.shields.io/github/last-commit/ruby-rdf/shacl) - A pure-Ruby library for working with the Shape Constraint Language to validate the shape of RDF graphs; `BSD-3-Clause` license; `Ruby`.
-- [shacl-engine](https://github.com/rdf-ext/shacl-engine) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/rdf-ext/shacl-engine" align="top"> - Supports SHACL Core, SHACL-SPARQL; A fast engine for data provided as [RDF/JS](http://rdf.js.org/data-model-spec/) objects; [playground](https://playground.rdf-ext.org/shacl/); `MIT` license; `JavaScript`.
-- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/TopQuadrant/shacl" align="top"> - Supports SHACL Core, SHACL-SPARQL, SHACL rules; based on Jena; `BSD-3-Clause` license; `Java`.
-- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/SHACL-X/shacl-x" align="top"> - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot; `BSD-3-Clause` license; `Java`.
+- [Apache Jena SHACL](https://github.com/apache/jena/tree/main/jena-shacl) <img alt="Maven Central Version" src="https://img.shields.io/maven-central/v/org.apache.jena/jena-shacl" align="top"> <img alt="Maven Central Last Update" src="https://img.shields.io/maven-central/last-update/org.apache.jena/jena-shacl" align="top"> - Supports SHACL Core, SHACL-SPARQL; [docs](https://jena.apache.org/documentation/shacl/index.html); `Apache-2.0` license; `Java`.
+- [RDF4J SHACL Engine](https://github.com/eclipse-rdf4j/rdf4j/tree/main/core/sail/shacl) <img alt="Maven Central Version" src="https://img.shields.io/maven-central/v/org.eclipse.rdf4j/rdf4j-shacl" align="top"> <img alt="Maven Central Last Update" src="https://img.shields.io/maven-central/last-update/org.eclipse.rdf4j/rdf4j-shacl" align="top"> - Supports SHACL Core (without some property paths), SHACL-SPARQL, incremental validation; [docs](https://rdf4j.org/documentation/programming/shacl/); `BSD-3-Clause` license; `Java`.
+- [rdf-validate-shacl](https://github.com/zazuko/rdf-validate-shacl) <img alt="NPM Version" src="https://img.shields.io/npm/v/rdf-validate-shacl" align="top"> <img alt="GitHub Release Date" src="https://img.shields.io/github/release-date/zazuko/rdf-validate-shacl" align="top"> - Supports SHACL Core; pure JavaScript validator on top of the [RDFJS](https://rdf.js.org/) stack; `MIT` license; `JavaScript`.
+  - [playground](https://zazuko.github.io/shacl-playground) - Browser-based testbed.
+- [SHACL for Ruby](https://github.com/ruby-rdf/shacl) <img alt="Gem Version" src="https://img.shields.io/gem/v/shacl" align="top"> <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/ruby-rdf/shacl" align="top"> - A pure-Ruby library for working with the Shape Constraint Language to validate the shape of RDF graphs; `BSD-3-Clause` license; `Ruby`.
+- [shacl-engine](https://github.com/rdf-ext/shacl-engine) <img alt="NPM Version" src="https://img.shields.io/npm/v/shacl-engine" align="top"> <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/rdf-ext/shacl-engine" align="top"> - Supports SHACL Core, SHACL-SPARQL; A fast engine for data provided as [RDF/JS](http://rdf.js.org/data-model-spec/) objects; `MIT` license; `JavaScript`.
+  - [playground](https://playground.rdf-ext.org/shacl/) - Browser-based testbed.
+  - [rdf-ext-cli](https://github.com/rdf-ext/rdf-ext-cli) - The command line tool provides a validation feature based on shacl-engine. Data and shapes can be given as file, URL, or SPARQL endpoint + query.
+- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) <img alt="Maven Central Version" src="https://img.shields.io/maven-central/v/org.topbraid/shacl" align="top"> <img alt="Maven Central Last Update" src="https://img.shields.io/maven-central/last-update/org.topbraid/shacl" align="top"> - Supports SHACL Core, SHACL-SPARQL, SHACL rules; based on Jena; `BSD-3-Clause` license; `Java`.
+  - [RDF validator](https://www.itb.ec.europa.eu/shacl/any/upload) - The EU Interoperability Test Bed (ITB) playground based on TQ API; validate any RDF with SHACL Shapes.
+  - [SHACL shapes validator](https://www.itb.ec.europa.eu/shacl/shacl/upload) - The EU Interoperability Test Bed (ITB) playgrounds based on TQ API; validate SHACL Shapes itself.
+  - [Sparna SHACL playground](https://shacl-play.sparna.fr/play/) - Free online suite of tools from Sparna to work with SHACL; based on TQ API.
+- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) <img alt="GitHub Release" src="https://img.shields.io/github/v/release/SHACL-X/shacl-x" align="top"> <img alt="GitHub Release Date" src="https://img.shields.io/github/release-date/SHACL-X/shacl-x" align="top"> - Fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot; [docs](https://shacl-x.github.io/docs/); `BSD-3-Clause` license; `Java`.
 
 ## ShEx Validators
 
-- [Apache Jena ShEx](https://github.com/apache/jena/tree/main/jena-shex) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - Supports ShEx, ShExC; not supported semantic actions, EXTERNAL; `Apache-2.0` license; `Java`.
-- [shexSpec/shex.js](https://github.com/shexjs/shex.js) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="top"> - JavaScript implementation of Shape Expressions; [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html); `MIT` license; `JavaScript`.
+- [Apache Jena ShEx](https://github.com/apache/jena/tree/main/jena-shex) <img alt="Maven Central Version" src="https://img.shields.io/maven-central/v/org.apache.jena/jena-shex" align="top"> <img alt="Maven Central Last Update" src="https://img.shields.io/maven-central/last-update/org.apache.jena/jena-shex" align="top"> - Supports ShEx, ShExC; not supported semantic actions, EXTERNAL; [docs](https://jena.apache.org/documentation/shex/); `Apache-2.0` license; `Java`.
+- [shexSpec/shex.js](https://github.com/shexjs/shex.js) <img alt="NPM Version" src="https://img.shields.io/npm/v/shex" align="top"> <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="top"> - JavaScript implementation of Shape Expressions; `MIT` license; `JavaScript`.
+  - [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html) - Browser-based testbed.
 - [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator" align="top"> ☠️ - A standalone Node module with a command line interface; `MIT` license; `JavaScript`.
-- [Validata](https://github.com/HW-SWeL/Validata) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata" align="top"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground1](http://hw-swel.github.io/Validata/), [playground2](https://www.w3.org/2015/03/ShExValidata/); `MIT` license; `JavaScript`.
+- [Validata](https://github.com/HW-SWeL/Validata) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata" align="top"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; `MIT` license; `JavaScript`.
+  - [playground1](http://hw-swel.github.io/Validata/)
+  - [playground2](https://www.w3.org/2015/03/ShExValidata/)
 
 ## Shapes Discovery Tools
 
@@ -58,7 +67,7 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 ## Shape Conversion Tools
 
 - [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter" align="top"> ☠️ - Shape shifter from SHACL to other formats (currently RDForms); `GPL-3.0` license; `Python`.
-- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/comake/shacl-to-json-schema" align="top"> - TS, SHACL-to-JSON-Schema translator; `Typescript`.
+- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) <img alt="NPM Version" src="https://img.shields.io/npm/v/@comake/shacl-to-json-schema" align="top"> <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/comake/shacl-to-json-schema" align="top"> - TS, SHACL-to-JSON-Schema translator; `Typescript`.
 
 ## Shape Generators
 
@@ -66,7 +75,8 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## Shape-based Query Generators
 
-- [shape-to-query](https://github.com/hypermedia-app/shape-to-query) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/hypermedia-app/shape-to-query" align="top"> - Generate SPARQL queries from SHACL Shapes; [playground](https://shape-to-query.hypermedia.app); `MIT` license; `Typescript`.
+- [shape-to-query](https://github.com/hypermedia-app/shape-to-query) <img alt="NPM Version" src="https://img.shields.io/npm/v/@hydrofoil/shape-to-query" align="top"> <img alt="GitHub Release Date" src="https://img.shields.io/github/release-date/hypermedia-app/shape-to-query" align="top"> - Generate SPARQL queries from SHACL Shapes; [docs](https://shape-to-query.hypermedia.app/docs); `MIT` license; `Typescript`.
+  - [playground](https://shape-to-query.hypermedia.app)
 
 ## Shape Editors, Visualizations
 
@@ -76,7 +86,8 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 Data viewers/Editors based on shapes.
 
-- [shaperone](https://github.com/hypermedia-app/shaperone) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/hypermedia-app/shaperone" align="top"> - SHACL Shapes Form generator; [playground](https://forms.hypermedia.app/playground); `MIT` license; `Typescript`.
+- [shaperone](https://github.com/hypermedia-app/shaperone) <img alt="NPM Version" src="https://img.shields.io/npm/v/@hydrofoil/shaperone-wc" align="top"> <img alt="GitHub Release Date" src="https://img.shields.io/github/release-date/hypermedia-app/shaperone" align="top"> - SHACL Shapes Form generator; [docs](https://forms.hypermedia.app); `MIT` license; `Typescript`.
+  - [playground](https://forms.hypermedia.app/playground)
 
 ## IDE support
 
@@ -107,7 +118,7 @@ Data viewers/Editors based on shapes.
   - [Shapes Constraint Language (SHACL)](https://www.w3.org/TR/shacl/) - W3C Recommendation, 20 July 2017.
   - [SHACL Advanced Features](https://www.w3.org/TR/shacl-af/) - W3C Working Group Note, 08 June 2017.
   - [SHACL JavaScript Extensions](https://www.w3.org/TR/shacl-js/) - W3C Working Group Note, 08 June 2017.
-  - [SHACL Test Suite and Implementation Report](https://w3c.github.io/data-shapes/data-shapes-test-suite/) - W3C Document 17 January 2024.
+  - [SHACL Test Suite and Implementation Report](https://w3c.github.io/data-shapes/data-shapes-test-suite/) - W3C Document 01 July 2019.
   - [SHACL Use Cases and Requirements](https://www.w3.org/TR/shacl-ucr/) - W3C Working Group Note 20 July 2017.
 
 - SHACL, Community Group Latest Drafts & Notes
@@ -116,6 +127,10 @@ Data viewers/Editors based on shapes.
   - [SHACL Advanced Features 1.1](https://w3c.github.io/shacl/shacl-af/)
   - [SHACL Compact Syntax](https://w3c.github.io/shacl/shacl-compact-syntax/)
   - [SHACL JavaScript Extensions](https://w3c.github.io/shacl/shacl-js/)
+
+- SHACL-related specifications
+  - [The Shape Topologies algorithm](https://treecg.github.io/specification/shape-topologies)
+  - [DASH Data Shapes](https://www.datashapes.org/) - Platform-independent extensions of SHACL for common tasks. Stuff that could become an official standard in the future.
 
 - ShEx
   - [Shape Expressions Language 2.1](https://shex.io/shex-semantics/index.html) - Final Community Group Report 8 October 2019.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 - [Shape Editors, Visualizations](#shape-editors-visualizations)
 - [Declarative UIs](#declarative-uis)
 - [IDE support](#ide-support)
-- [Book](#book)
+- [Books](#books)
 - [Tutorials](#tutorials)
 - [Presentations](#presentations)
 - [Specifications](#specifications)
@@ -40,7 +40,7 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 ## ShEx Validators
 
 - [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - `Apache-2.0` `Java`.
-- [shexSpec/shex.js](https://github.com/shexjs/shex.js)<img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="top"> - [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html) - `MIT` `JavaScript`.
+- [shexSpec/shex.js](https://github.com/shexjs/shex.js)<img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="top"> - [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html); `MIT` `JavaScript`.
 - [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator)<img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator" align="top"> - :skull:  `MIT` `JavaScript`.
 - [Validata](https://github.com/HW-SWeL/Validata)<img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata" align="top"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground](http://hw-swel.github.io/Validata/); [playground](https://www.w3.org/2015/03/ShExValidata/); `MIT` `JavaScript`.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 - [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/apache/jena" align="top"> - Supports ShEx, ShExC; not supported semantic actions, EXTERNAL; `Apache-2.0` `Java`.
 - [shexSpec/shex.js](https://github.com/shexjs/shex.js) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/shexjs/shex.js" align="top"> - JavaScript implementation of Shape Expressions; [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html); `MIT` `JavaScript`.
-- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator" align="top"> - A standalone Node module with a command line interface; :skull: `MIT` `JavaScript`.
+- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/ShEx-validator" align="top"> :skull: - A standalone Node module with a command line interface; `MIT` `JavaScript`.
 - [Validata](https://github.com/HW-SWeL/Validata) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/HW-SWeL/Validata" align="top"> - An intuitive, standalone web-based tool to help building RDF documents by validating against preset schemas written in the ShEx language; [playground](http://hw-swel.github.io/Validata/); [playground](https://www.w3.org/2015/03/ShExValidata/); `MIT` `JavaScript`.
 
 ## Shapes Discovery Tools
@@ -57,7 +57,7 @@ Semantic shapes are frequently described using the SHACL or ShEx language.
 
 ## Shape Conversion Tools
 
-- [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter" align="top"> - Shape shifter from SHACL to other formats (currently RDForms); :skull: `GPL-3.0` `Python`.
+- [ShacShifter](https://github.com/AKSW/ShacShifter) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/AKSW/ShacShifter" align="top"> :skull: - Shape shifter from SHACL to other formats (currently RDForms); `GPL-3.0` `Python`.
 - [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/comake/shacl-to-json-schema" align="top"> - TS, SHACL-to-JSON-Schema translator; `Typescript`.
 
 ## Shape Generators

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Awesome Semantic Shapes [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-> A curated list of Semantic Shapes resources. Contributions welcome! Please, read the [Contribution Guidelines](CONTRIBUTING.md) first.
+> A curated list of Semantic Shapes resources. Contributions welcome!
+> Please, read the [Contribution Guidelines](CONTRIBUTING.md) first.
 
-Semantic shapes enables you to validate RDF graphs against a set of conditions. Semantic shapes can also be viewed as a description of the data graphs that do satisfy these conditions. Such descriptions may be used for a variety of purposes beside validation, including user interface building, code generation and data integration. Semantic shapes could be described in SHACL or ShEx languages.
+Semantic shapes enable you to validate RDF graphs against a set of conditions.
+Semantic shapes can also be viewed as a description of the data graphs that do satisfy these conditions.
+Such descriptions may be used for a variety of purposes beside validation,
+including user interface building, code generation and data integration.
+Semantic shapes could be described in SHACL or ShEx languages.
 
 ## Contents
 
@@ -14,6 +19,7 @@ Semantic shapes enables you to validate RDF graphs against a set of conditions. 
 - [Shape Generators](#shape-generators)
 - [Shape Editors, Visualizations](#shape-editors-visualizations)
 - [Declarative UIs](#declarative-uis)
+- [IDE support](#ide-support)
 - [Book](#book)
 - [Tutorials](#tutorials)
 - [Presentations](#presentations)
@@ -22,36 +28,36 @@ Semantic shapes enables you to validate RDF graphs against a set of conditions. 
 
 ## SHACL Validators
 
-- [Jena SHACL](https://github.com/apache/jena/) -- Java, Supports: SHACL Core, SHACL-SPARQL
-- [RDF4J SHACL Sail](https://github.com/eclipse-rdf4j/rdf4j) -- Java
-- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) -- Java, based on Jena, supports: SHACL Core, SHACL-SPARQL, SHACL rules
-- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) -- Java, fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot
+- [Jena SHACL](https://github.com/apache/jena/) - Java, Supports: SHACL Core, SHACL-SPARQL.
+- [RDF4J SHACL Sail](https://github.com/eclipse-rdf4j/rdf4j) - Java.
+- [TopBraid SHACL API](https://github.com/TopQuadrant/shacl) - Java, based on Jena, supports: SHACL Core, SHACL-SPARQL, SHACL rules.
+- [TopBraid SHACL API Extended](https://github.com/SHACL-X/shacl-x) - Java, fork of TopBraid SHACL API + added SHACL-JS based on GraalVM Polyglot.
 
 ## ShEx Validators
 
-- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) -- Java
-- [shexSpec/shex.js](https://github.com/shexjs/shex.js) -- JS, [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html)
-- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) -- JS
-- [Validata](https://github.com/HW-SWeL/Validata) -- JS, [playground](http://hw-swel.github.io/Validata/), [playground](https://www.w3.org/2015/03/ShExValidata/)
+- [Apache Jena ShEx](https://jena.apache.org/documentation/shex/index.html) - Java.
+- [shexSpec/shex.js](https://github.com/shexjs/shex.js) - [playground](http://rawgit.com/shexSpec/shex.js/master/doc/shex-simple.html) - JS.
+- [ShEx-validator](https://github.com/HW-SWeL/ShEx-validator) - JS.
+- [Validata](https://github.com/HW-SWeL/Validata) - [playground](http://hw-swel.github.io/Validata/) - [playground](https://www.w3.org/2015/03/ShExValidata/), JS.
 
 ## Shapes Discovery Tools
 
-- [RDFminer](https://github.com/Wimmics/RDFminer) -- Web application to automatically discovering SHACL shapes representative of an RDF data graph, by Wimmics
+- [RDFminer](https://github.com/Wimmics/RDFminer) - Web application to automatically discovering SHACL shapes representative of an RDF data graph, by Wimmics.
 - [SHACL Discovery Service](https://github.com/AKSW/discover-shacl-shapes)
-- [Shapes of You index](https://index.semanticscience.org/) -- SPARQL queries, OWL/SKOS vocabularies, SHACL/ShEx shapes indexed from public git repositories.
+- [Shapes of You index](https://index.semanticscience.org/) - SPARQL queries, OWL/SKOS vocabularies, SHACL/ShEx shapes indexed from public git repositories.
 
 ## Shapes Collections
 
-- [schema.org Shapes](http://datashapes.org/schema) -- Schema.org, converted to SHACL by TopQuadrant
+- [schema.org Shapes](http://datashapes.org/schema) - Schema.org, converted to SHACL by TopQuadrant.
 
 ## Shape Conversion Tools
 
-- [ShacShifter](https://github.com/AKSW/ShacShifter) -- Python, ☠️, "shape shifter" from SHACL to other formats (currently RDForms)
-- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) -- TS, SHACL To JSON Schema translator
+- [ShacShifter](https://github.com/AKSW/ShacShifter) - Python, ☠️, "shape shifter" from SHACL to other formats (currently RDForms).
+- [SHACL To JSON Schema](https://github.com/comake/shacl-to-json-schema) - TS, SHACL To JSON Schema translator.
 
 ## Shape Generators
 
-- [owl2shacl](https://github.com/sparna-git/owl2shacl) -- OWL 2 SHACL conversion rules
+- [owl2shacl](https://github.com/sparna-git/owl2shacl) - OWL 2 SHACL conversion rules.
 
 ## Shape Editors, Visualizations
 
@@ -61,11 +67,15 @@ Semantic shapes enables you to validate RDF graphs against a set of conditions. 
 
 Data viewers/Editors based on shapes.
 
-- [shaperone](https://forms.hypermedia.app) -- SHACL Shapes Form generator
+- [shaperone](https://forms.hypermedia.app) - SHACL Shapes Form generator.
+
+## IDE support
+
+- [Linked Data Extension](https://github.com/elsevierlabs-os/linked-data) - VS Code Extension for RDF files editing with embedded SHACL validator and SPARQL engine.
 
 ## Book
 
-- [Validating RDF Data (2018)](https://book.validatingrdf.com/) 
+- [Validating RDF Data (2018)](https://book.validatingrdf.com/)
 
 ## Tutorials
 
@@ -76,22 +86,25 @@ Data viewers/Editors based on shapes.
 ## Specifications
 
 - SHACL, W3C Recommendations & Notes
-  - [Shapes Constraint Language (SHACL)](https://www.w3.org/TR/shacl/) -- W3C Recommendation, 20 July 2017
-  - [SHACL Advanced Features](https://www.w3.org/TR/shacl-af/) -- W3C Working Group Note, 08 June 2017
-  - [SHACL JavaScript Extensions](https://www.w3.org/TR/shacl-js/) -- W3C Working Group Note, 08 June 2017
-  - [SHACL Test Suite and Implementation Report](https://w3c.github.io/data-shapes/data-shapes-test-suite/) -- W3C Document 17 January 2024
-  - [SHACL Use Cases and Requirements](https://www.w3.org/TR/shacl-ucr/) -- W3C Working Group Note 20 July 2017
+  - [Shapes Constraint Language (SHACL)](https://www.w3.org/TR/shacl/) - W3C Recommendation, 20 July 2017.
+  - [SHACL Advanced Features](https://www.w3.org/TR/shacl-af/) - W3C Working Group Note, 08 June 2017.
+  - [SHACL JavaScript Extensions](https://www.w3.org/TR/shacl-js/) - W3C Working Group Note, 08 June 2017.
+  - [SHACL Test Suite and Implementation Report](https://w3c.github.io/data-shapes/data-shapes-test-suite/) - W3C Document 17 January 2024.
+  - [SHACL Use Cases and Requirements](https://www.w3.org/TR/shacl-ucr/) - W3C Working Group Note 20 July 2017.
+
 - SHACL, Community Group Latest Drafts & Notes
   - [SHACL 1.2 Core](https://w3c.github.io/shacl/shacl-core/)
   - [SHACL 1.2 SPARQL Extensions](https://w3c.github.io/shacl/shacl-sparql/)
   - [SHACL Advanced Features 1.1](https://w3c.github.io/shacl/shacl-af/)
   - [SHACL Compact Syntax](https://w3c.github.io/shacl/shacl-compact-syntax/)
   - [SHACL JavaScript Extensions](https://w3c.github.io/shacl/shacl-js/)
+
 - ShEx
-  - [Shape Expressions Language 2.1](https://shex.io/shex-semantics/index.html) -- Final Community Group Report 8 October 2019
+  - [Shape Expressions Language 2.1](https://shex.io/shex-semantics/index.html) - Final Community Group Report 8 October 2019.
+
 - ShEx, Drafts
   - [P3330TM/D3 Draft Recommended Practice for Standard for Shape Expression Schemas](https://shexspec.github.io/spec/)
 
 ## Legend
-☠️ -- each one denotes every 5 year from last update
-💰 -- denotes closed source commercial software
+☠️ -- Each one denotes every 5 year from last update.
+💰 -- Denotes closed source commercial software.


### PR DESCRIPTION
README with the Contents and initial structure of sections.

Some sections entries migrated from [Updated list of implementations](https://github.com/validatingrdf/validatingrdf.github.io/wiki/Updated-list-of-implementations) as an examples. It is not a complete migration, just an illustration.

Closes #1 