### PR TITLE
Add sheXer to Shapes Discovery Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Software tools or libraries, sorted by programming language.
 - [SHACL Discovery Service](https://github.com/AKSW/discover-shacl-shapes) - Discovery service for SHACL shapes/shape groups; `MIT` license; `PHP`.
 - [Shapes of You index](https://index.semanticscience.org/) - SPARQL queries, OWL/SKOS vocabularies, SHACL/ShEx shapes, indexed from public `git` repositories; `MIT` license; `Typescript`, `Python`.
 - [SHACL Play! Catalog](https://shacl-play.sparna.fr/play/shapes-catalog) - To see your shapes listed here, add them in the [Shapes Catalog source file on Github](https://github.com/sparna-git/SHACL-Catalog/blob/master/shacl-catalog.ttl).
+- [sheXer](https://github.com/weso/shexer/) - Library to extract ShEx/SHACL shapes from RDF data, SPARQL endpoints, or rdflib graphs. It offers iterative parsing and/or sampling to deal with big datasets; `Apache` License; `Python`.
 
 ## Shapes Collections
 


### PR DESCRIPTION
The tool I'm proposing to include in "Shapes Discovery Tools" section is mature and has been maintained for several years (still is).  You can see technical details in its [main publication](https://doi.org/10.1016/j.knosys.2021.107975). As its main developer, I'm aware of a number of projects (unrelated to myslef nor my group) which are using it. Some can be found in the [dependants tab of sheXer's Github repository](https://github.com/weso/shexer/network/dependents?dependents_before=MTUzNjIwMTg0MTA).